### PR TITLE
Enable tab completion on a Mac

### DIFF
--- a/ansible-shell
+++ b/ansible-shell
@@ -178,4 +178,12 @@ class AnsibleShell(cmd.Cmd):
 
 
 if __name__ == '__main__':
+    # This hack is to work around readline issues on a mac:
+    #  http://stackoverflow.com/a/7116997/541202
+    import readline
+    import rlcompleter
+    if 'libedit' in readline.__doc__:
+        readline.parse_and_bind("bind ^I rl_complete")
+    else:
+        readline.parse_and_bind("tab: complete")
     AnsibleShell().cmdloop()


### PR DESCRIPTION
This fix enables tab completion on a Mac.

See links for background:
  http://stackoverflow.com/a/7116997/541202
  http://docs.python.org/2/library/readline.html
