### PR TITLE
Check for ANSIBLE_LIBRARY environment variable

### DIFF
--- a/ansible-shell
+++ b/ansible-shell
@@ -49,8 +49,9 @@ class AnsibleShell(cmd.Cmd):
         self.prompt += '$ '
 
     def list_modules(self):
+        module_path = os.environ.get("ANSIBLE_LIBRARY", DIST_MODULE_PATH)
         modules = []
-        for root, dirs, files in os.walk(DIST_MODULE_PATH):
+        for root, dirs, files in os.walk(module_path):
             for basename in files:
                 modules.append(basename)
 


### PR DESCRIPTION
If ANSIBLE_LIBRARY is defined in the environment, use it to set the module path.
