### PR TITLE
fix module inclusion path when running from source

### DIFF
--- a/ansible-shell
+++ b/ansible-shell
@@ -4,7 +4,7 @@
 import cmd
 import ansible.runner
 from ansible.color import stringc
-from ansible.constants import DIST_MODULE_PATH
+from ansible.constants import DEFAULT_MODULE_PATH
 from ansible import utils
 import ansible.utils.module_docs as module_docs
 import sys
@@ -49,9 +49,8 @@ class AnsibleShell(cmd.Cmd):
         self.prompt += '$ '
 
     def list_modules(self):
-        module_path = os.environ.get("ANSIBLE_LIBRARY", DIST_MODULE_PATH)
         modules = []
-        for root, dirs, files in os.walk(module_path):
+        for root, dirs, files in os.walk(DEFAULT_MODULE_PATH):
             for basename in files:
                 modules.append(basename)
 


### PR DESCRIPTION
This is an old patch I've had in a local branch but had not submitted.
I've rebased it to effectively undo Lorin Hochstein's commit cc47d4c. While
that commit also worked I think this version is more correct as it
ensures that ansible-shell module path behavior mirrors that of ansible
itself. ansible uses DEFAULT_MODULE_PATH, not DIST_MODULE_PATH to set
module_path if -M is not used, as shown on line 474 in
lib/ansible/utils/**init**.py

The previous search paths assumed that ansible was installed on the
system. This meant that it did not work if running ansible from a
source checkout without installing it via pip (or other means.) More
insidiously, if a user was running from a source checkout, but also
installed ansible in system paths, ansible-shell used the system
version of ansible modules, not the source version.
