### PR TITLE
add timeout to optionparse and ansible runner

### DIFF
--- a/ansible-shell
+++ b/ansible-shell
@@ -92,6 +92,9 @@ class AnsibleShell(cmd.Cmd):
         return modules
 
     def default(self, arg, forceshell=False):
+        if arg.startswith("#"):
+            return False
+
         if not self.cwd:
             print "No host found"
             return False


### PR DESCRIPTION
This fixes the bug reported in #14 

``` python
>>> Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/ansible/runner/__init__.py", line 382, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/usr/local/lib/python2.7/site-packages/ansible/runner/__init__.py", line 471, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "/usr/local/lib/python2.7/site-packages/ansible/runner/__init__.py", line 637, in _executor_internal_inner
    conn = self.connector.connect(actual_host, actual_port, actual_user, actual_pass, actual_transport, actual_private_key_file)
  File "/usr/local/lib/python2.7/site-packages/ansible/runner/connection.py", line 39, in connect
    self.active = conn.connect()
  File "/usr/local/lib/python2.7/site-packages/ansible/runner/connection_plugins/ssh.py", line 96, in connect
    self.common_args += ["-o", "ConnectTimeout=%d" % self.runner.timeout]
TypeError: %d format: a number is required, not str
```
