### PR TITLE
Don't assume an ansible configuration file exists.

### DIFF
--- a/ansible-shell
+++ b/ansible-shell
@@ -204,7 +204,7 @@ class AnsibleShell(cmd.Cmd):
         if not arg:
             print 'Usage: serial <number>'
             return
-        self.options.serial = arg
+        self.options.serial = int(arg)
         self.set_prompt()
 
     def do_cd(self, arg):


### PR DESCRIPTION
If an ansible configuration file does not exist then `C.load_config_file()` returns `None` which causes the program to crash. This fixes it by checking if a config file was found before using it.
