### PR TITLE
Batches in serialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /ansible_shell.egg-info
 venv
 
+# py.test
+/ansible-shellc
+__pycache__/
+/.cache/

--- a/ansible-shell
+++ b/ansible-shell
@@ -161,20 +161,31 @@ class AnsibleShell(cmd.Cmd):
 
         contacted = {}
         dark = {}
+        # TODO: interrupting still doesn't really work
+        interrupted = False
         for batch_hosts in batches:
-            self.ansible.inventory.also_restrict_to(batch_hosts)
-            results = self._run_module(module, module_args)
-            self.ansible.inventory.lift_also_restriction()
+            try:
+                self.ansible.inventory.also_restrict_to(batch_hosts)
+                results = self._run_module(module, module_args)
+                if results is False:
+                    interrupted = True
+            finally:
+                self.ansible.inventory.lift_also_restriction()
+
+            if interrupted:
+                print
+                break
 
             self._print_contacted_hosts(results['contacted'])
             contacted.update(results['contacted'])
             dark.update(results['dark'])
-
             self._print_progress_line(contacted, dark)
 
-        self._print_dark_hosts(dark)
-        self._print_progress_line(contacted, dark)
-        print
+        if not interrupted:
+            # TODO: use callback_plugin to get partial stats
+            self._print_dark_hosts(dark)
+            self._print_progress_line(contacted, dark)
+            print
 
     def _run_module(self, module, module_args):
         try:
@@ -188,7 +199,7 @@ class AnsibleShell(cmd.Cmd):
                 inventory=self.ansible.inventory
             ).run()
         except Exception as e:
-            print e.msg
+            print unicode(e)
             return False
 
         return results

--- a/ansible-shell
+++ b/ansible-shell
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import cmd
+import curses.ascii
 import ansible.runner
 from ansible.color import stringc, codeCodes
 import ansible.constants as C
@@ -11,6 +12,7 @@ from ansible.inventory import Host
 import ansible.utils.module_docs as module_docs
 import sys
 import os
+import operator
 import pwd
 import readline
 import rlcompleter
@@ -157,10 +159,22 @@ class AnsibleShell(cmd.Cmd):
             self.ansible.inventory.list_hosts(opts.cwd),
             opts.serial)
 
+        contacted = {}
+        dark = {}
         for batch_hosts in batches:
             self.ansible.inventory.also_restrict_to(batch_hosts)
-            self._run_module(module, module_args)
+            results = self._run_module(module, module_args)
             self.ansible.inventory.lift_also_restriction()
+
+            self._print_contacted_hosts(results['contacted'])
+            contacted.update(results['contacted'])
+            dark.update(results['dark'])
+
+            self._print_progress_line(contacted, dark)
+
+        self._print_dark_hosts(dark)
+        self._print_progress_line(contacted, dark)
+        print
 
     def _run_module(self, module, module_args):
         try:
@@ -177,7 +191,10 @@ class AnsibleShell(cmd.Cmd):
             print e.msg
             return False
 
-        for (hostname, result) in results['contacted'].items():
+        return results
+
+    def _print_contacted_hosts(self, contacted):
+        for (hostname, result) in contacted.items():
             print "=============== %-30s ================" % stringc(hostname, 'bright gray')
 
             if 'stderr' in result.keys():
@@ -195,10 +212,30 @@ class AnsibleShell(cmd.Cmd):
                 else:
                     callbacks.display(utils.jsonify(result,True), 'red')
 
+    def _print_dark_hosts(self, dark):
         # connect failed
-        for (hostname, result) in results['dark'].items():
+        for (hostname, result) in dark.items():
             print "=============== %s ================" % stringc(hostname, 'red')
             callbacks.display(result['msg'], 'red')
+
+    def _print_progress_line(self, contacted, dark):
+        failures = 0
+        successes = 0
+        for result in contacted.values():
+            if result.get('failed') or result.get('rc', 0) != 0:
+                failures += 1
+            else:
+                successes += 1
+
+        sys.stdout.write(
+            u'Done: {done}/{all}, success: {successes}, failures: {failures}, dark: {dark}{CR}'
+            .format(
+                done=len(contacted) + len(dark),
+                all=len(self.ansible.inventory.list_hosts(self.options.cwd)),
+                successes=stringc(unicode(successes), 'green') if successes else '0',
+                failures=stringc(unicode(failures), 'red') if failures else '0',
+                dark=stringc(unicode(len(dark)), 'red') if dark else '0',
+                CR=chr(curses.ascii.CR)))
 
     def emptyline(self):
         return
@@ -337,4 +374,3 @@ if __name__ == '__main__':
 
     (options, args) = AnsibleShell.parse_opts()
     AnsibleShell(options, args).cmdloop()
-

--- a/ansible-shell
+++ b/ansible-shell
@@ -152,19 +152,27 @@ class AnsibleShell(cmd.Cmd):
             callbacks.display("Command canceled by user")
             return
 
+        opts = self.options
+        batches = get_hosts_batches(
+            self.ansible.inventory.list_hosts(opts.cwd),
+            opts.serial)
+
+        for batch_hosts in batches:
+            self.ansible.inventory.also_restrict_to(batch_hosts)
+            self._run_module(module, module_args)
+            self.ansible.inventory.lift_also_restriction()
+
+    def _run_module(self, module, module_args):
         try:
             opts = self.options
             results = ansible.runner.Runner(
-                pattern=self.options.cwd, forks=self.options.serial,
+                pattern=self.options.cwd,
                 module_name=module, module_args=module_args,
                 remote_user=opts.remote_user,
                 sudo=opts.sudo, sudo_user=opts.sudo_user,
                 timeout=int(opts.timeout),
-                host_list=opts.host_list
+                inventory=self.ansible.inventory
             ).run()
-            if results is None:
-                print "No hosts found"
-                return False
         except Exception as e:
             print e.msg
             return False
@@ -191,7 +199,6 @@ class AnsibleShell(cmd.Cmd):
         for (hostname, result) in results['dark'].items():
             print "=============== %s ================" % stringc(hostname, 'red')
             callbacks.display(result['msg'], 'red')
-
 
     def emptyline(self):
         return
@@ -298,6 +305,20 @@ class AnsibleShell(cmd.Cmd):
 
     def do_dump(self, a):
         print readline.get_current_history_length()
+
+
+def get_hosts_batches(hosts, serial):
+    """Return hosts from inventory in batches based on the `serial` option"""
+    if not hosts:
+        return []
+    if serial == 0:
+        return [hosts]
+    serialized_batch = []
+    all_hosts = list(hosts)
+    while all_hosts:
+        serialized_batch.append(all_hosts[:serial])
+        del all_hosts[:serial]
+    return serialized_batch
 
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pytest]
+python_files=tests.py test_*.py

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,19 @@
+import pytest
+import imp
+import os
+
+ansible_shell_path = os.path.dirname(__file__) + '/ansible-shell'
+with open(ansible_shell_path) as f:
+    ansible_shell = imp.load_module(
+        'ansible_shell', f, ansible_shell_path, ('', 'U', 1))
+
+
+@pytest.mark.parametrize(('hosts', 'serial', 'result'), [
+    (['a', 'b'], 1, [['a'], ['b']]),
+    (['a', 'b', 'c'], 2, [['a', 'b'], ['c']]),
+    ([], 1, []),
+    ([], 0, []),
+    (['a', 'b'], 0, [['a', 'b']]),
+])
+def test_generating_batches(hosts, serial, result):
+    assert result == ansible_shell.get_hosts_batches(hosts, serial)


### PR DESCRIPTION
So far "serialize" was implemented by setting forks on Runner. This made results only visible after all hosts were contacted.

This PR changes it so it's an actual loop over batches of hosts (like in ansible-playbook) and shows results after each batch (that's the "Run and report each batch separately" commit).
It also adds a status line that shows how many hosts have been contacted so far, and number of successes/module failures/connection failures ("Add progress information when running tasks").
There were some problem with Ctrl-C, and I think it's still not really resolved (maybe even re-initializing Runner would be needed?) - this needs more testing.

I also smuggled in a test setup - if you like it, I volunteer to add some more tests and Travis CI integration. If not, I'll happily remove it from this PR.