### PR TITLE
DEFAULT_MODULE_PATH is empty by default

### DIFF
--- a/ansible-shell
+++ b/ansible-shell
@@ -101,9 +101,10 @@ class AnsibleShell(cmd.Cmd):
 
     def list_modules(self):
         modules = []
-        for root, dirs, files in os.walk(C.DEFAULT_MODULE_PATH):
-            for basename in files:
-                modules.append(basename)
+        if C.DEFAULT_MODULE_PATH:
+            for root, dirs, files in os.walk(C.DEFAULT_MODULE_PATH):
+                for basename in files:
+                    modules.append(basename)
 
         return modules
 


### PR DESCRIPTION
With ansible 1.8, I get:
```
$ ../ansible-shell/ansible-shell -i ansible/inventory/development/infra
Traceback (most recent call last):
  File "../ansible-shell/ansible-shell", line 318, in <module>
    AnsibleShell(options, args).cmdloop()
  File "../ansible-shell/ansible-shell", line 48, in __init__
    self.modules = self.list_modules()
  File "../ansible-shell/ansible-shell", line 104, in list_modules
    for root, dirs, files in os.walk(C.DEFAULT_MODULE_PATH):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/os.py", line 276, in walk
    names = listdir(top)
TypeError: coercing to Unicode: need string or buffer, NoneType found
```

The default for `DEFAULT_MODULE_PATH` is now `None`.
https://github.com/ansible/ansible/blob/16c4c378bd925fccac17a12d3e74d63f7e4156a6/lib/ansible/constants.py#L102