### PR TITLE
walk param may be None in macos

### DIFF
--- a/ansible-shell
+++ b/ansible-shell
@@ -145,7 +145,8 @@ class AnsibleShell(cmd.Cmd):
         modules = set()
         module_paths = ansible.utils.plugins.module_finder._get_paths()
         for path in module_paths:
-            modules.update(self._find_modules_in_path(path))
+	    if paht is not None:
+            	modules.update(self._find_modules_in_path(path))
 
         return modules
 

--- a/ansible-shell
+++ b/ansible-shell
@@ -145,7 +145,7 @@ class AnsibleShell(cmd.Cmd):
         modules = set()
         module_paths = ansible.utils.plugins.module_finder._get_paths()
         for path in module_paths:
-	    if paht is not None:
+	    if path is not None:
             	modules.update(self._find_modules_in_path(path))
 
         return modules


### PR DESCRIPTION
I use ansible-shell in MacOS,But this error:

    File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/os.py", line 276, in walk
        names = listdir(top)
    TypeError: coercing to Unicode: need string or buffer, NoneType found

I found walk param "path" may be is None.

sorry,I write error var word. :(